### PR TITLE
latest clang and clangd setup (:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ build/*
 test_vids/*
 .devcontainer/*
 .vscode/*
-compile_commands.json

--- a/dockerfiles/clang_dev.dockerfile
+++ b/dockerfiles/clang_dev.dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:11.2.0
+FROM gcc:11.3.0
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -7,11 +7,11 @@ RUN apt-get install -y \
 
 RUN pip3 install ninja
 
-RUN git clone https://github.com/llvm/llvm-project.git && \
-    cd llvm-project && \
-    git checkout llvmorg-13.0.0 && \
-    cmake -S llvm -B build -G "Ninja" -DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;lld;libunwind;lldb;polly;debuginfo-tests" -DCMAKE_BUILD_TYPE="Release" && \
-    cmake --build build -j 8
+RUN git clone https://github.com/llvm/llvm-project.git
+RUN cd llvm-project && \
+    git checkout llvmorg-14.0.3 && \
+    cmake -S llvm -B build -G "Ninja" -DLLVM_ENABLE_PROJECTS="clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;lld;libunwind;lldb;polly" -DCMAKE_BUILD_TYPE="Release" && \
+    cmake --build build
 
 RUN apt-get install -y \
     gdb
@@ -22,12 +22,19 @@ RUN pip3 install conan && \
     conan profile update settings.compiler.libcxx=libstdc++11 default && \
     conan config set general.revisions_enabled=1
 
-RUN conan profile new clang --detect && \
-    conan profile update settings.compiler.libcxx=libstdc++11 clang && \
-    conan profile update settings.compiler=clang clang && \
-    conan profile update settings.compiler.version=13 clang && \
-    conan profile update env.CC=/llvm-project/build/bin/clang clang && \
-    conan profile update env.CXX=/llvm-project/build/bin/clang++ clang
+RUN conan profile new clang-stdcxx --detect && \
+    conan profile update settings.compiler.libcxx=libstdc++11 clang-stdcxx && \
+    conan profile update settings.compiler=clang clang-stdcxx && \
+    conan profile update settings.compiler.version=15 clang-stdcxx && \
+    conan profile update env.CC=/llvm-project/build/bin/clang clang-stdcxx && \
+    conan profile update env.CXX=/llvm-project/build/bin/clang++ clang-stdcxx
+
+RUN conan profile new clang-libcxx --detect && \
+    conan profile update settings.compiler.libcxx=libc++ clang-libcxx  && \
+    conan profile update settings.compiler=clang clang-libcxx  && \
+    conan profile update settings.compiler.version=15 clang-libcxx  && \
+    conan profile update env.CC=/llvm-project/build/bin/clang clang-libcxx  && \
+    conan profile update env.CXX=/llvm-project/build/bin/clang++ clang-libcxx 
 
 ENV CONAN_SYSREQUIRES_SUDO=False
 ENV CONAN_SYSREQUIRES_MODE=enabled

--- a/dockerfiles/readme.md
+++ b/dockerfiles/readme.md
@@ -11,9 +11,11 @@ Includes latest versions of clang and gcc, and development and build tools like 
 
 #### Commands for Development:
 
+if you are familiar with conan feel free to use your own commands (:
+
 Install Dependencies:
 ```
-conan install . --profile clang -if build --build missing -s build_type=Debug
+conan install . --profile clang-libcxx -if build --build missing -s build_type=Debug
 ```
 note: you can omit the profile argument to build with gcc instead
 
@@ -25,12 +27,23 @@ note: if you want to switch between building with clang and gcc first delete you
 
 #### Clangd vscode setup
 
-Add the following to your settings.json in vscode (assuming you're using the clang_dev image)
+Add the following to you devcontainer.json
+
+```
+"extensions": [
+		"llvm-vs-code-extensions.vscode-clangd"
+]
+```
+
+Add the following to your settings.json (assuming you're using the clang_dev image and ./build as your build folder)
 
 ```
 "clangd.path":"/llvm-project/build/bin/clangd"
+"clangd.arguments": ["-compile-commands-dir=/workspaces/luma_av/build"]
 ```
 Note: clangd will work for some things but probably wont be accurate until we can fully compile the project with clang
+
+Troubleshootng: for the best results, do the following after making any changes to clangd config or the build enviornment: rebuild the contaner and call conan install and conan build before opening your first cpp source/header file
 
 ### gcc_dev (deprecated)
 


### PR DESCRIPTION
- image updated with latest clang and gcc releases. also separate profiles for clang libcxx and libstdcxx so we can easily use one or the other. also use default parallelization instead of j8 so we avoid making assumptions about the users hardware. _also_ the llvm clone step is a separate docker layer since the clone step is so costly and i want to minimize repeating it. 
- dockerfiles/readme.md updated conan instructions and added more thorough clangd setup instructions (:
- also removed compilecommands.json from the gitignore since it goes in the build folder now and is therefor already ignored (: 

tldr clangd "works" now (i.e. works for the parts of the project that currently compile with clang). wooo!! (: 