### PR TITLE
clang tidy (:

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,5 +14,6 @@
             "key": "x",
             "value": "y"
         }
-    ]
+    ],
+    "FormatStyle": "file"
 }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,12 +8,53 @@
             performance-*,
             portability-*,
             readability-*,
+            readability-identifier-naming,
             ",
     "CheckOptions": [
         {
-            "key": "x",
-            "value": "y"
-        }
+            "key": "readability-identifier-naming.ClassMemberCase",
+            "value": "lower_case",
+        },
+        {
+            "key": "readability-identifier-naming.ClassMethodCase",
+            "value": "lower_case",
+        },
+        {
+            "key": "readability-identifier-naming.ClassCase",
+            "value": "CamelCase",
+        },
+        {
+            "key": "readability-identifier-naming.EnumCase",
+            "value": "CamelCase",
+        },
+        {
+            "key": "readability-identifier-naming.EnumConstantCase",
+            "value": "lower_case",
+        },
+        {
+            "key": "readability-identifier-naming.FunctionCase",
+            "value": "lower_case",
+        },
+        {
+            "key": "readability-identifier-naming.GlobalConstantCase",
+            "value": "camelBack",
+        },
+        {
+            "key": "readability-identifier-naming.GlobalVariableCase",
+            "value": "camelBack",
+        },
+        {
+            "key": "readability-identifier-naming.ParameterCase",
+            "value": "lower_case",
+        },
+        {
+            "key": "readability-identifier-naming.StructCase",
+            "value": "CamelCase",
+        },
+        {
+            "key": "readability-identifier-naming.VariableCase",
+            "value": "lower_case",
+        },
     ],
     "FormatStyle": "file"
 }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,18 @@
+{
+    "Checks": "-*,
+            bugprone-*,
+            clang-analyzer-*,
+            concurrency-*,
+            cppcoreguidelines-*,
+            modernize-*,
+            performance-*,
+            portability-*,
+            readability-*,
+            ",
+    "CheckOptions": [
+        {
+            "key": "x",
+            "value": "y"
+        }
+    ]
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,6 +15,7 @@ class LumaAvConan(ConanFile):
         "shared": False,
         "ffmpeg:with_opus": False,
         "ffmpeg:with_libalsa": False,
+        "ffmpeg:with_libx265": False,
         "gtest:build_gmock": False
     }
     generators = "cmake", "cmake_find_package"

--- a/dockerfiles/readme.md
+++ b/dockerfiles/readme.md
@@ -60,6 +60,16 @@ to run clang-tidy on the whole project run the following from the build folder (
 ```
 python3 /llvm-project/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -clang-tidy-binary /llvm-project/build/bin/clang-tidy
 ```
+note: this command will run checks based on the .clang-tidy file in the project root. 
+
+to automatically apply fixes, add the following to your command. this will also apply our formatting to any code thats auto fixed.
+
+```
+-fix -clang-apply-replacements-binary /llvm-project/build/bin/clang-apply-replacements -format
+```
+
+see `run-clang-tidy.py --help` and https://clang.llvm.org/extra/clang-tidy/ for more info (: 
+
 
 you can also add a task to your vscode task.json using the following as an example
 

--- a/dockerfiles/readme.md
+++ b/dockerfiles/readme.md
@@ -51,6 +51,32 @@ formatting with vscode "just works" with the c++ extension in vscode due to the 
 
 unfortunately, I think at this time the vscode c++ extension is using its own copy of clang format and not the newer version in the image. this is something we'll ideally address in the future but isnt a priority for now since the formatting still works. 
 
+#### Running clang-tidy
+
+these commands use the install location for the clang_dev image, but they can of course be adapted for other install locations
+
+to run clang-tidy on the whole project run the following from the build folder (or wherever youve placed the compile commands json)
+
+```
+python3 /llvm-project/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -clang-tidy-binary /llvm-project/build/bin/clang-tidy
+```
+
+you can also add a task to your vscode task.json using the following as an example
+
+```
+{
+            "label": "clang-tidy",
+            "type": "shell",
+            "command": "python3 /llvm-project/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -clang-tidy-binary /llvm-project/build/bin/clang-tidy",
+            "options": {
+                "cwd": "${workspaceRoot}/build"
+            },
+            "problemMatcher": []
+}
+```
+
+note: there may be a better way, but I ususally have to ask vscode to rebuild the container in order for task.json changes to take affect. 
+
 
 ### gcc_dev (deprecated)
 

--- a/dockerfiles/readme.md
+++ b/dockerfiles/readme.md
@@ -43,7 +43,7 @@ Add the following to your settings.json (assuming you're using the clang_dev ima
 ```
 Note: clangd will work for some things but probably wont be accurate until we can fully compile the project with clang
 
-Troubleshootng: for the best results, do the following after making any changes to clangd config or the build enviornment: rebuild the contaner and call conan install and conan build before opening your first cpp source/header file
+Troubleshootng: for the best results, do the following after making any changes to clangd config or the build enviornment: rebuild the contaner and call conan install and conan build before opening your first cpp source/header file. Note: I think closing all open source files will also work to restart/refresh clangd.
 
 #### Formatting with vscode and clang-format
 

--- a/examples/avio_reading_example.cpp
+++ b/examples/avio_reading_example.cpp
@@ -29,6 +29,7 @@ TEST(AvioReadingExample, MyExample) {
     auto custom_reader = 
             [bd = BufferData{map_buff.data(), map_buff.size()}] 
             (uint8_t *buf, int buf_size) mutable -> int {
+        // NOLINTBEGIN
         buf_size = FFMIN(buf_size, bd.size);
         if (!buf_size)
             return AVERROR_EOF;
@@ -38,6 +39,7 @@ TEST(AvioReadingExample, MyExample) {
         bd.ptr  += buf_size;
         bd.size -= buf_size;
         return buf_size;
+        // NOLINTEND
     };
 
     auto io_callbacks = luma_av::CustomIOFunctions{}.CustomRead(std::move(custom_reader));
@@ -50,7 +52,7 @@ TEST(AvioReadingExample, MyExample) {
     av_dump_format(fctx.get(), 0, input_filename.c_str(), 0);
 }
 
-
+// NOLINTBEGIN 
 struct buffer_data {
     uint8_t *ptr;
     size_t size; ///< size left in the buffer
@@ -128,3 +130,4 @@ end:
         fprintf(stderr, "Error occurred: %s\n", "av_err2str(ret)");
     }
 }
+// NOLINTEND

--- a/examples/decode_video_example.cpp
+++ b/examples/decode_video_example.cpp
@@ -17,6 +17,7 @@ extern "C" {
 static auto kFileName = "./test_vids/fortnite_mpeg1_cut.mp4";
 static auto kOutputFile = "./test_vids/outputs/output_uwu";
 
+// NOLINTBEGIN
 #define INBUF_SIZE 4096
 static void pgm_save(const uint8_t* buf, int wrap, int xsize, int ysize,
                      const char *filename)
@@ -29,6 +30,7 @@ static void pgm_save(const uint8_t* buf, int wrap, int xsize, int ysize,
         fwrite(buf + i * wrap, 1, xsize, f);
     fclose(f);
 }
+// NOLINTEND
 
 TEST(DecodeVideoExample, MyExample) {
     auto parser = luma_av::Parser::make(AV_CODEC_ID_MPEG1VIDEO).value();
@@ -43,9 +45,11 @@ TEST(DecodeVideoExample, MyExample) {
     auto fc = luma_av::detail::finally([&](){
         fclose(f);
     });
+    // NOLINTBEGIN
     uint8_t inbuf[INBUF_SIZE + AV_INPUT_BUFFER_PADDING_SIZE];
     /* set end of buffer to 0 (this ensures that no overreading happens for damaged MPEG streams) */
     memset(inbuf + INBUF_SIZE, 0, AV_INPUT_BUFFER_PADDING_SIZE);
+    // NOLINTEND
 
     int frame_num = 0;
     auto save_frames = [&](const auto& res) {
@@ -53,6 +57,7 @@ TEST(DecodeVideoExample, MyExample) {
             std::cout << "error!!! " << res.error().message() << std::endl;
         }
         auto&& frame = *res.value();
+        // NOLINTBEGIN
         printf("saving frame %3d\n", frame_num);
         fflush(stdout);
         char buf[1024];
@@ -62,6 +67,7 @@ TEST(DecodeVideoExample, MyExample) {
         pgm_save(frame.data()[0], frame.linesize()[0],
             frame.width(), frame.height(), buf);
         ++frame_num;
+        // NOLINTEND
     };
     while (!feof(f)) {
         /* read raw data from the input file */
@@ -119,7 +125,7 @@ TEST(DecodeVideoExample, MyExampleStdFileScaling) {
                             | luma_av::views::scale(sws), save_frames);
 }
 
-
+// NOLINTBEGIN
 static void decode(AVCodecContext *dec_ctx, AVFrame *frame, AVPacket *pkt,
                    const char *filename)
 {
@@ -234,3 +240,4 @@ TEST(DecodeVideoExample, FullFFmpegExample)
     av_frame_free(&frame);
     av_packet_free(&pkt);
 }
+// NOLINTEND

--- a/examples/filtering_video_example.cpp
+++ b/examples/filtering_video_example.cpp
@@ -1,9 +1,11 @@
 // example based on https://ffmpeg.org/doxygen/trunk/filtering_video_8c-example.html
 
+// NOLINTBEGIN
 #define _XOPEN_SOURCE 600 /* for usleep */
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+// NOLINTEND
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -29,6 +31,7 @@ TEST(FilterVideoExample, MyExample) {
 
     auto my_display_frame = [last_pts = int64_t{0}]
                 (const AVFrame *frame, AVRational time_base) mutable {
+        // NOLINTBEGIN
         int x, y;
         uint8_t *p0, *p;
         int64_t delay;
@@ -54,6 +57,7 @@ TEST(FilterVideoExample, MyExample) {
             p0 += frame->linesize[0];
         }
         fflush(stdout);
+        // NOLINTEND
     };
 
     const auto input_filename = luma_av::cstr_view{kFileName};
@@ -113,7 +117,7 @@ TEST(FilterVideoExample, MyExample) {
     std::ranges::for_each(pipe, display);
 }
 
-
+// NOLINTBEGIN
 const char *filter_descr = "scale=78:24,transpose=cclock";
 /* other way:
    scale=78:24 [scl]; [scl] transpose=cclock // assumes "[in]" and "[out]" to be input output pads respectively
@@ -328,3 +332,4 @@ end:
         exit(1);
     }
 }
+// NOLINTEND

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -8,11 +8,13 @@
             performance-*,
             portability-*,
             readability-*,
-            readability-identifier-naming,
             -modernize-use-trailing-return-type,
             -cppcoreguidelines-init-variables,
             -readability-identifier-length,
-            -readability-implicit-bool-conversion
+            -readability-implicit-bool-conversion,
+
+            -readability-identifier-naming,
+            -readability-named-parameter
             ",
     "CheckOptions": [
         {
@@ -36,20 +38,12 @@
             "value": "lower_case",
         },
         {
-            "key": "readability-identifier-naming.FunctionCase",
-            "value": "lower_case",
-        },
-        {
             "key": "readability-identifier-naming.GlobalConstantCase",
             "value": "camelBack",
         },
         {
             "key": "readability-identifier-naming.GlobalVariableCase",
             "value": "camelBack",
-        },
-        {
-            "key": "readability-identifier-naming.NamespaceCase",
-            "value": "lower_case",
         },
         {
             "key": "readability-identifier-naming.ParameterCase",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
+find_package(GTest REQUIRED)
+
 add_subdirectory(unit)
 add_subdirectory(integration)

--- a/tests/integration/avio_reading_int_tests.cpp
+++ b/tests/integration/avio_reading_int_tests.cpp
@@ -75,6 +75,7 @@ static void LumaAVReadExample() {
     av_log_set_callback(av_log_default_callback);
 }
 
+// NOLINTBEGIN
 struct buffer_data {
     uint8_t *ptr;
     size_t size; ///< size left in the buffer
@@ -158,7 +159,7 @@ end:
         fprintf(stderr, "Error occurred: %s\n", "av_err2str(ret)");
     }
 }
-
+// NOLINTEND
 
 TEST(AVIOreadTests, FfmpegCompare) {
     LumaAVReadExample();

--- a/tests/integration/decode_video_int_tests.cpp
+++ b/tests/integration/decode_video_int_tests.cpp
@@ -41,7 +41,7 @@ extern "C" {
 static constexpr auto kFileName = "./test_vids/fortnite_mpeg1_cut.mp4";
 static constexpr auto kFrameCompCount = int{10};
 
-#define INBUF_SIZE 4096
+#define INBUF_SIZE 4096 // NOLINT
 
 static std::vector<std::vector<uint8_t>> LumaAvDecodeVideo() {
     auto parser = luma_av::Parser::make(AV_CODEC_ID_MPEG1VIDEO).value();
@@ -89,6 +89,7 @@ static std::vector<std::vector<uint8_t>> LumaAvDecodeVideo() {
 }
 
 
+// NOLINTBEGIN
 static std::vector<std::vector<uint8_t>> FFmpegDecodeVideoExample()
 {
     const auto decode = [](AVCodecContext *dec_ctx, AVFrame *frame, AVPacket *pkt,
@@ -203,7 +204,7 @@ static std::vector<std::vector<uint8_t>> FFmpegDecodeVideoExample()
     av_packet_free(&pkt);
     return frame_data;
 }
-
+// NOLINTEND
 
 TEST(DecodeVideoIntegration, FfmpegComparison) {
     const auto luma_frames = LumaAvDecodeVideo();
@@ -224,6 +225,7 @@ note: packet free'd first
 TEST(DecodeVideoIntegration, ParserParseOne) {
     auto parser = luma_av::Parser::make(AV_CODEC_ID_MPEG1VIDEO).value();
     auto filename    = kFileName;
+    // NOLINTBEGIN
     FILE* f = fopen(filename, "rb");
     if (!f) {
         fprintf(stderr, "Could not open %s\n", filename);
@@ -235,6 +237,7 @@ TEST(DecodeVideoIntegration, ParserParseOne) {
     uint8_t inbuf[INBUF_SIZE + AV_INPUT_BUFFER_PADDING_SIZE];
     /* set end of buffer to 0 (this ensures that no overreading happens for damaged MPEG streams) */
     memset(inbuf + INBUF_SIZE, 0, AV_INPUT_BUFFER_PADDING_SIZE);
+    // NOLINTEND
     
     while (!feof(f)) {
         /* read raw data from the input file */

--- a/tests/integration/filter_int_tests.cpp
+++ b/tests/integration/filter_int_tests.cpp
@@ -26,6 +26,7 @@ using namespace luma_av_literals;
 static auto kFileName = "./test_vids/fortnite_mpeg1_cut.mp4";
 
 static void my_display_frame(const AVFrame *frame, AVRational time_base, int64_t& last_pts, std::stringstream& disp) {
+    // NOLINTBEGIN
     int x, y;
     uint8_t *p0, *p;
     int64_t delay;
@@ -51,6 +52,7 @@ static void my_display_frame(const AVFrame *frame, AVRational time_base, int64_t
         p0 += frame->linesize[0];
     }
     disp << std::endl;
+    // NOLINTEND
 };
 
 static std::string LumaAVFilterVideoEx() {
@@ -114,6 +116,7 @@ static std::string LumaAVFilterVideoEx() {
     return std::move(disp).str();
 }
 
+// NOLINTBEGIN
 static std::string ffmpegFilterVideoEx() {
 
     const char *filter_descr = "scale=78:24,transpose=cclock";
@@ -303,6 +306,7 @@ static std::string ffmpegFilterVideoEx() {
         }
     return std::move(disp).str();
 }
+// NOLINTEND
 
 
 TEST(FilterIntTests, FFmpegComparison) {


### PR DESCRIPTION
adds instructions for using clang tidy with this project (: along with clang-tidy files for the project and tests and a few initial nolint suppressions. the test specific clang tidy file was added to deal with the extra suppressions needed to deal with gtest macros. 

checks are pretty tentative right now. I basically just picked everything on this page that didnt seem to be specific to a particular organization/project https://clang.llvm.org/extra/clang-tidy/#id2. and then a few opinionated suppressions based on an initial output, so those are also pretty tentative. 

the casing options for the `readability-identifier-naming` are less tentative :p the main motivation for this casing is that different things should look different, also combined with my personal preference (: 

also snuck in a few misc fixes. we werent actually calling find package for gest in the test target 😅  also for whatever reason the conan install for gcc fails unless you disable x265. so both of those are fixed now (: 