### PR TITLE
clang-tidy fixes and disabling ranges for clang builds (:

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -65,7 +65,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock

--- a/examples/decode_video_example.cpp
+++ b/examples/decode_video_example.cpp
@@ -1,8 +1,8 @@
 // example based on https://ffmpeg.org/doxygen/trunk/decode_video_8c-example.html
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 extern "C" {
 #include <libavcodec/avcodec.h>
 }
@@ -35,8 +35,8 @@ static void pgm_save(const uint8_t* buf, int wrap, int xsize, int ysize,
 TEST(DecodeVideoExample, MyExample) {
     auto parser = luma_av::Parser::make(AV_CODEC_ID_MPEG1VIDEO).value();
     auto decoder = luma_av::Decoder::make(AV_CODEC_ID_MPEG1VIDEO).value();
-    auto filename    = kFileName;
-    auto outfilename = kOutputFile;
+    const auto* filename = kFileName;
+    const auto* outfilename = kOutputFile;
     FILE* f = fopen(filename, "rb");
     if (!f) {
         fprintf(stderr, "Could not open %s\n", filename);
@@ -72,8 +72,9 @@ TEST(DecodeVideoExample, MyExample) {
     while (!feof(f)) {
         /* read raw data from the input file */
         auto data_size = fread(inbuf, 1, INBUF_SIZE, f);
-        if (!data_size)
-            break;
+        if (!data_size) {
+          break;
+        }
         std::span<const uint8_t> data(inbuf, data_size);
         // this is a bug idk why i need to make a vector
         //  a single view should work? i.e. std::views::single(data);
@@ -89,8 +90,8 @@ TEST(DecodeVideoExample, MyExampleStdFileScaling) {
     auto parser = luma_av::Parser::make(AV_CODEC_ID_MPEG1VIDEO).value();
     auto decoder = luma_av::Decoder::make(AV_CODEC_ID_MPEG1VIDEO).value();
     auto sws = luma_av::ScaleSession::make(luma_av::ScaleOpts{640_w, 460_h, AV_PIX_FMT_RGB24}).value();
-    auto filename    = kFileName;
-    auto outfilename = kOutputFile;
+    const auto* filename = kFileName;
+    const auto* outfilename = kOutputFile;
 
     std::ifstream ifs(filename, std::ios::binary);
     LUMA_AV_ASSERT(ifs.is_open());

--- a/examples/decode_video_example.cpp
+++ b/examples/decode_video_example.cpp
@@ -1,5 +1,5 @@
 // example based on https://ffmpeg.org/doxygen/trunk/decode_video_8c-example.html
-
+#ifdef  LUMA_AV_ENABLE_RANGES
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -242,3 +242,4 @@ TEST(DecodeVideoExample, FullFFmpegExample)
     av_packet_free(&pkt);
 }
 // NOLINTEND
+#endif  // LUMA_AV_ENABLE_RANGES

--- a/examples/filtering_video_example.cpp
+++ b/examples/filtering_video_example.cpp
@@ -1,5 +1,5 @@
 // example based on https://ffmpeg.org/doxygen/trunk/filtering_video_8c-example.html
-
+#ifdef  LUMA_AV_ENABLE_RANGES
 // NOLINTBEGIN
 #define _XOPEN_SOURCE 600 /* for usleep */
 #include <unistd.h>
@@ -334,3 +334,4 @@ end:
     }
 }
 // NOLINTEND
+#endif  // LUMA_AV_ENABLE_RANGES

--- a/examples/filtering_video_example.cpp
+++ b/examples/filtering_video_example.cpp
@@ -65,7 +65,7 @@ TEST(FilterVideoExample, MyExample) {
     fctx.FindStreamInfo().value();
     fctx.FindBestStream(AVMEDIA_TYPE_VIDEO).value();
     const auto vid_idx = fctx.stream_index(AVMEDIA_TYPE_VIDEO);
-    const auto vid_codec = fctx.codec(AVMEDIA_TYPE_VIDEO);
+    const auto* const vid_codec = fctx.codec(AVMEDIA_TYPE_VIDEO);
     auto dec_ctx = luma_av::CodecContext::make(vid_codec, fctx.stream(vid_idx)->codecpar).value();
     const auto time_base = fctx.stream(vid_idx)->time_base;
 
@@ -75,10 +75,11 @@ TEST(FilterVideoExample, MyExample) {
             .PixFormat(dec_ctx.get()->pix_fmt)
             .AspectRatio(dec_ctx.get()->sample_aspect_ratio)
             .TimeBase(time_base);
-    const auto src_filt = luma_av::FindFilter("buffer"_cstr).value();
+    const auto* const src_filt = luma_av::FindFilter("buffer"_cstr).value();
     filter_graph.CreateSrcFilter(src_filt, "in"_cstr, filter_args).value();
 
-    const auto sink_filt = luma_av::FindFilter("buffersink"_cstr).value();
+    const auto* const sink_filt =
+        luma_av::FindFilter("buffersink"_cstr).value();
     filter_graph.CreateSinkFilter(sink_filt, "out"_cstr).value();
     
     std::vector<AVPixelFormat> pix_fmts{AV_PIX_FMT_GRAY8, AV_PIX_FMT_NONE};
@@ -95,9 +96,9 @@ TEST(FilterVideoExample, MyExample) {
     const auto is_video = [&](auto const& pkt_res){
         if(pkt_res.has_value()) {
             return pkt_res.value()->get()->stream_index == vid_idx;
-        } else {
-            return true;
         }
+        return true;
+       
     };
     const auto set_frame_pts = [](const auto& frame_res) -> std::decay_t<decltype(frame_res)> {
         LUMA_AV_OUTCOME_TRY(frame, frame_res);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,9 +15,6 @@ target_link_libraries(luma_av PUBLIC
 
 target_sources(luma_av PRIVATE codec.cpp)
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_compile_definitions(luma_av PUBLIC LUMA_AV_ENABLE_RANGES)
-endif()
 
 
 add_library(luma_av::luma_av ALIAS luma_av)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,5 +15,9 @@ target_link_libraries(luma_av PUBLIC
 
 target_sources(luma_av PRIVATE codec.cpp)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_definitions(luma_av PUBLIC LUMA_AV_ENABLE_RANGES)
+endif()
+
 
 add_library(luma_av::luma_av ALIAS luma_av)

--- a/src/include/luma_av/codec.hpp
+++ b/src/include/luma_av/codec.hpp
@@ -15,6 +15,7 @@ extern "C" {
 #include <luma_av/frame.hpp>
 #include <luma_av/packet.hpp>
 #include <luma_av/util.hpp>
+#include <luma_av/detail/ranges_config.hpp>
 
 /*
 https://ffmpeg.org/doxygen/3.2/group__lavc__decoding.html#ga8f5b632a03ce83ac8e025894b1fc307a

--- a/src/include/luma_av/codec.hpp
+++ b/src/include/luma_av/codec.hpp
@@ -496,6 +496,7 @@ struct EncodeInterfaceImpl {
     // they already have the same .start_draining()
 };
 
+#ifdef LUMA_AV_ENABLE_RANGES
 // i dont understand why these specific concepts
 template <class EncDecInterface, std::ranges::view R>
 class encdec_view_impl : public std::ranges::view_interface<encdec_view_impl<EncDecInterface, R>> {
@@ -774,9 +775,11 @@ auto operator()(coder_type& dec) const {
             encdec_view_impl_fn<EncDec>>{encdec_view_impl_fn<EncDec>{}, dec};
 }
 };
+#endif  // LUMA_AV_ENABLE_RANGES
 
 } // detail
 
+#ifdef LUMA_AV_ENABLE_RANGES
 inline const auto decode_view = detail::encdec_view_impl_fn<detail::DecodeInterfaceImpl>{};
 inline const auto encode_view = detail::encdec_view_impl_fn<detail::EncodeInterfaceImpl>{};
 
@@ -975,6 +978,8 @@ inline const auto drain_view = detail::drain_view_fn{};
 namespace views {
 inline const auto drain = drain_view;
 } // views
+
+#endif  // LUMA_AV_ENABLE_RANGES
 
 } // luma_av
 

--- a/src/include/luma_av/detail/ranges_config.hpp
+++ b/src/include/luma_av/detail/ranges_config.hpp
@@ -1,0 +1,4 @@
+
+#ifndef __clang__
+#define LUMA_AV_ENABLE_RANGES 1
+#endif

--- a/src/include/luma_av/filter.hpp
+++ b/src/include/luma_av/filter.hpp
@@ -19,6 +19,7 @@ extern "C" {
 #include <luma_av/frame.hpp>
 #include <luma_av/result.hpp>
 #include <luma_av/util.hpp>
+#include <luma_av/detail/ranges_config.hpp>
 
 namespace luma_av {
 

--- a/src/include/luma_av/filter.hpp
+++ b/src/include/luma_av/filter.hpp
@@ -254,6 +254,7 @@ struct AddFrameClosure {
     }
 };
 
+#ifdef LUMA_AV_ENABLE_RANGES 
 
 // i dont understand why these specific concepts
 template <std::ranges::view R>
@@ -477,14 +478,17 @@ auto operator()(FilterSession& filt) const {
 }
 };
 
+#endif  // LUMA_AV_ENABLE_RANGES
+
 } // detail
 
+#ifdef LUMA_AV_ENABLE_RANGES
 inline const auto filter_graph_view = detail::filter_graph_view_impl_fn{};
 
 namespace views {
 inline const auto filter_graph = filter_graph_view;
-
 } // views
+#endif  // LUMA_AV_ENABLE_RANGES
 
 } // luma_av
 

--- a/src/include/luma_av/format.hpp
+++ b/src/include/luma_av/format.hpp
@@ -18,6 +18,7 @@ extern "C" {
 #include <luma_av/frame.hpp>
 #include <luma_av/result.hpp>
 #include <luma_av/util.hpp>
+#include <luma_av/detail/ranges_config.hpp>
 
 namespace luma_av {
 

--- a/src/include/luma_av/format.hpp
+++ b/src/include/luma_av/format.hpp
@@ -296,7 +296,8 @@ class format_context {
             if (ret < 0) {
                 return errc{ret};
             }
-            streams_infos_.insert_or_assign(type, StreamInfo{ret, codec});
+            streams_infos_.insert_or_assign(
+                type, StreamInfo{static_cast<size_t>(ret), codec});
             return luma_av::outcome::success();
         }
         bool Contains(AVMediaType type) noexcept {

--- a/src/include/luma_av/format.hpp
+++ b/src/include/luma_av/format.hpp
@@ -464,6 +464,7 @@ class Reader {
 
 };
 
+#ifdef LUMA_AV_ENABLE_RANGES
 namespace detail {
 // i dont understand why these specific concepts
 template <std::ranges::view R>
@@ -656,6 +657,8 @@ inline const auto read_input_view = detail::input_reader_view_fn{};
 namespace views {
 inline const auto read_input = read_input_view;
 } // views
+
+#endif  // LUMA_AV_ENABLE_RANGES
 
 
 

--- a/src/include/luma_av/parser.hpp
+++ b/src/include/luma_av/parser.hpp
@@ -62,7 +62,8 @@ std::pair<result<std::span<const uint8_t>>, std::span<const uint8_t>> ParseStep(
     } else if (!(data_out) or (size_out == 0)) {
         return {errc::parser_hungry_uwu, in_buff.subspan(ret)};
     } else {
-        return {std::span<uint8_t>{data_out, size_out}, in_buff.subspan(ret)};
+      return {std::span<uint8_t>{data_out, static_cast<std::size_t>(size_out)},
+              in_buff.subspan(ret)};
     }
 }
 std::pair<result<void>, std::span<const uint8_t>> ParseStep(Packet& out_pkt, 

--- a/src/include/luma_av/parser.hpp
+++ b/src/include/luma_av/parser.hpp
@@ -14,6 +14,7 @@ extern "C" {
 #include <luma_av/codec.hpp>
 #include <luma_av/result.hpp>
 #include <luma_av/util.hpp>
+#include <luma_av/detail/ranges_config.hpp>
 
 namespace luma_av {
 

--- a/src/include/luma_av/swscale.hpp
+++ b/src/include/luma_av/swscale.hpp
@@ -149,6 +149,8 @@ struct ScaleClosure {
         return sws.Scale(frame);
     }
 };
+
+#ifdef LUMA_AV_ENABLE_RANGES
 const auto scale_view = [](ScaleSession& sws){
     return std::views::transform([&](const auto& frame) {
         return ScaleClosure{sws}(frame);
@@ -158,7 +160,7 @@ const auto scale_view = [](ScaleSession& sws){
 namespace views {
 const auto scale = scale_view;
 } // views
-
+#endif  // LUMA_AV_ENABLE_RANGES
 
 
 } // luma_av

--- a/src/include/luma_av/swscale.hpp
+++ b/src/include/luma_av/swscale.hpp
@@ -14,6 +14,7 @@ extern "C" {
 #include <luma_av/frame.hpp>
 #include <luma_av/result.hpp>
 #include <luma_av/util.hpp>
+#include <luma_av/detail/ranges_config.hpp>
 
 
 namespace luma_av {

--- a/tests/integration/avio_reading_int_tests.cpp
+++ b/tests/integration/avio_reading_int_tests.cpp
@@ -1,5 +1,5 @@
 
-
+#ifdef  LUMA_AV_ENABLE_RANGES
 // example based on https://ffmpeg.org/doxygen/trunk/avio_reading_8c-example.html
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -188,3 +188,4 @@ TEST(AVIOreadTests, file_map) {
   ASSERT_EQ(map_buff.size(), buffer_size);
 }
 
+#endif  // LUMA_AV_ENABLE_RANGES

--- a/tests/integration/avio_reading_int_tests.cpp
+++ b/tests/integration/avio_reading_int_tests.cpp
@@ -53,8 +53,9 @@ static void LumaAVReadExample() {
             [bd = BufferData{map_buff.data(), map_buff.size()}] 
             (uint8_t *buf, int buf_size) mutable -> int {
         buf_size = FFMIN(buf_size, bd.size);
-        if (!buf_size)
-            return AVERROR_EOF;
+        if (!buf_size) {
+          return AVERROR_EOF;
+        }
         luma_output << bd.size << "\n";
         /* copy internal buffer data to buf */
         memcpy(buf, bd.ptr, buf_size);
@@ -175,13 +176,15 @@ TEST(AVIOreadTests, FfmpegCompare) {
 verify that our MappedFileBuff aggrees with av_file_map on the size of the file
 */
 TEST(AVIOreadTests, file_map) {
-    uint8_t *buffer = NULL;
-    size_t buffer_size;
-    const auto input_filename = luma_av::cstr_view{kFileName};
-    ASSERT_EQ(av_file_map(input_filename.c_str(), &buffer, &buffer_size, 0, NULL), 0);
-    av_file_unmap(buffer, buffer_size);
-    
-    const auto map_buff = luma_av::MappedFileBuff::make(input_filename).value();
-    ASSERT_EQ(map_buff.size(), buffer_size);
+  uint8_t* buffer = nullptr;
+  size_t buffer_size;
+  const auto input_filename = luma_av::cstr_view{kFileName};
+  ASSERT_EQ(
+      av_file_map(input_filename.c_str(), &buffer, &buffer_size, 0, nullptr),
+      0);
+  av_file_unmap(buffer, buffer_size);
+
+  const auto map_buff = luma_av::MappedFileBuff::make(input_filename).value();
+  ASSERT_EQ(map_buff.size(), buffer_size);
 }
 

--- a/tests/integration/decode_video_int_tests.cpp
+++ b/tests/integration/decode_video_int_tests.cpp
@@ -25,6 +25,8 @@
  *
  * @example decode_video.c
  */
+
+#ifdef  LUMA_AV_ENABLE_RANGES
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -299,3 +301,5 @@ TEST(DecodeVideoIntegration, ParserFullParse) {
     }
     ASSERT_FALSE(parsed.empty());
 }
+
+#endif  // LUMA_AV_ENABLE_RANGES

--- a/tests/integration/decode_video_int_tests.cpp
+++ b/tests/integration/decode_video_int_tests.cpp
@@ -25,9 +25,9 @@
  *
  * @example decode_video.c
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 extern "C" {
 #include <libavcodec/avcodec.h>
 }
@@ -46,7 +46,7 @@ static constexpr auto kFrameCompCount = int{10};
 static std::vector<std::vector<uint8_t>> LumaAvDecodeVideo() {
     auto parser = luma_av::Parser::make(AV_CODEC_ID_MPEG1VIDEO).value();
     auto decoder = luma_av::Decoder::make(AV_CODEC_ID_MPEG1VIDEO).value();
-    auto filename    = kFileName;
+    const auto* filename = kFileName;
     FILE* f = fopen(filename, "rb");
     if (!f) {
         fprintf(stderr, "Could not open %s\n", filename);
@@ -72,8 +72,9 @@ static std::vector<std::vector<uint8_t>> LumaAvDecodeVideo() {
     while (!feof(f)) {
         /* read raw data from the input file */
         auto data_size = fread(inbuf, 1, INBUF_SIZE, f);
-        if (!data_size)
-            break;
+        if (!data_size) {
+          break;
+        }
         std::span<const uint8_t> data(inbuf, data_size);
         // this is a bug idk why i need to make a vector
         //  a single view should work? i.e. std::views::single(data);
@@ -224,7 +225,7 @@ note: packet free'd first
 */
 TEST(DecodeVideoIntegration, ParserParseOne) {
     auto parser = luma_av::Parser::make(AV_CODEC_ID_MPEG1VIDEO).value();
-    auto filename    = kFileName;
+    const auto* filename = kFileName;
     // NOLINTBEGIN
     FILE* f = fopen(filename, "rb");
     if (!f) {
@@ -242,8 +243,9 @@ TEST(DecodeVideoIntegration, ParserParseOne) {
     while (!feof(f)) {
         /* read raw data from the input file */
         auto data_size = fread(inbuf, 1, INBUF_SIZE, f);
-        if (!data_size)
-            break;
+        if (!data_size) {
+          break;
+        }
         std::span<const uint8_t> data(inbuf, data_size);
         // this is a bug idk why i need to make a vector
         //  a single view should work? i.e. std::views::single(data);
@@ -265,7 +267,7 @@ note: parser free'd first
 */
 TEST(DecodeVideoIntegration, ParserFullParse) {
     auto parser = luma_av::Parser::make(AV_CODEC_ID_MPEG1VIDEO).value();
-    auto filename    = kFileName;
+    const auto* filename = kFileName;
     FILE* f = fopen(filename, "rb");
     if (!f) {
         fprintf(stderr, "Could not open %s\n", filename);
@@ -282,8 +284,9 @@ TEST(DecodeVideoIntegration, ParserFullParse) {
     while (!feof(f)) {
         /* read raw data from the input file */
         auto data_size = fread(inbuf, 1, INBUF_SIZE, f);
-        if (!data_size)
-            break;
+        if (!data_size) {
+          break;
+        }
         std::span<const uint8_t> data(inbuf, data_size);
         // this is a bug idk why i need to make a vector
         //  a single view should work? i.e. std::views::single(data);

--- a/tests/integration/filter_int_tests.cpp
+++ b/tests/integration/filter_int_tests.cpp
@@ -1,5 +1,5 @@
 // example based on https://ffmpeg.org/doxygen/trunk/filtering_video_8c-example.html
-
+#ifdef  LUMA_AV_ENABLE_RANGES
 #define XOPEN_SOURCE 600 /* for usleep */
 #include <unistd.h>
 
@@ -316,3 +316,4 @@ TEST(FilterIntTests, FFmpegComparison) {
     const auto ffmpeg_results = ffmpegFilterVideoEx();
     ASSERT_EQ(our_results, ffmpeg_results);
 }
+#endif  // LUMA_AV_ENABLE_RANGES

--- a/tests/unit/luma_av/codec_tests.cpp
+++ b/tests/unit/luma_av/codec_tests.cpp
@@ -51,7 +51,7 @@ TEST(codec, encode_array) {
   Encode(enc, frames, std::back_inserter(packets)).value();
   Drain(enc, std::back_inserter(packets)).value();
 }
-
+#ifdef  LUMA_AV_ENABLE_RANGES
 TEST(codec, encode_single) {
     AVFrame* frame = nullptr;
 
@@ -445,3 +445,5 @@ TEST(codec, ParseyUwU) {
         out_pkts.push_back(std::move(pkt));
     }
 }
+
+#endif  // LUMA_AV_ENABLE_RANGES

--- a/tests/unit/luma_av/codec_tests.cpp
+++ b/tests/unit/luma_av/codec_tests.cpp
@@ -41,15 +41,15 @@ TEST(codec, encode_vector) {
 }
 
 TEST(codec, encode_array) {
-    std::array<AVFrame*, 5> frames; 
+  std::array<AVFrame*, 5> frames{};
 
-    auto enc = DefaultEncoder("h264").value();
+  auto enc = DefaultEncoder("h264").value();
 
-    std::vector<Packet> packets;
-    packets.reserve(5);
+  std::vector<Packet> packets;
+  packets.reserve(5);
 
-    Encode(enc, frames, std::back_inserter(packets)).value();
-    Drain(enc, std::back_inserter(packets)).value();
+  Encode(enc, frames, std::back_inserter(packets)).value();
+  Drain(enc, std::back_inserter(packets)).value();
 }
 
 TEST(codec, encode_single) {
@@ -65,38 +65,38 @@ TEST(codec, encode_single) {
 }
 
 TEST(codec, transcode_ranges) {
-    std::array<AVPacket*, 5> pkts; 
+  std::array<AVPacket*, 5> pkts{};
 
-    auto dec = DefaultDecoder("h264").value();
-    auto enc = DefaultEncoder("h264").value();
+  auto dec = DefaultDecoder("h264").value();
+  auto enc = DefaultEncoder("h264").value();
 
-    std::vector<Packet> out_pkts;
-    out_pkts.reserve(5);
+  std::vector<Packet> out_pkts;
+  out_pkts.reserve(5);
 
-    for (auto const& pkt : pkts | decode_view(dec) | encode_view(enc)) {
-        if (pkt) {
-            out_pkts.push_back(Packet::make(*pkt.value()).value());
-        } else if (pkt.error().value() == AVERROR(EAGAIN)) {
-            continue;
-        } else {
-            throw std::system_error{pkt.error()};
-        }
+  for (auto const& pkt : pkts | decode_view(dec) | encode_view(enc)) {
+    if (pkt) {
+      out_pkts.push_back(Packet::make(*pkt.value()).value());
+    } else if (pkt.error().value() == AVERROR(EAGAIN)) {
+      continue;
+    } else {
+      throw std::system_error{pkt.error()};
+    }
     }
 }
 
 TEST(codec, transcode_functions) {
-    std::array<AVPacket*, 5> pkts; 
+  std::array<AVPacket*, 5> pkts{};
 
-    auto dec = DefaultDecoder("h264").value();
-    auto enc = DefaultEncoder("h264").value();
+  auto dec = DefaultDecoder("h264").value();
+  auto enc = DefaultEncoder("h264").value();
 
-    std::vector<Frame> out_frames;
-    out_frames.reserve(5);
-    Decode(dec, pkts, std::back_inserter(out_frames)).value();
+  std::vector<Frame> out_frames;
+  out_frames.reserve(5);
+  Decode(dec, pkts, std::back_inserter(out_frames)).value();
 
-    std::vector<Packet> out_pkts;
-    out_pkts.reserve(5);
-    Encode(enc, out_frames, std::back_inserter(out_pkts)).value();
+  std::vector<Packet> out_pkts;
+  out_pkts.reserve(5);
+  Encode(enc, out_frames, std::back_inserter(out_pkts)).value();
 }
 
 


### PR DESCRIPTION
clang tidy auto fixes (: 

and a temporary trick for disabling ranges when building with clang or using clang tooling.  these parts dont compile with clang yet anyway and I think having them disabled makes the clang tooling output nicer (: 

also pointer alignment is left now :p I tried to make it that way from the beginning, but I'm not that great at using clang-format yet :p 

