### PR TITLE
ctest support for unit tests (:

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -17,10 +17,8 @@ jobs:
       - name: conan install (Release)
         timeout-minutes: 2
         run: conan install . -if build --build missing -s build_type=Release
-      - name: build
+      - name: build and test
         run: conan build . -bf build
-      - name: run unit tests
-        run: ./build/tests/unit/luma_av_unit 
         
   clang_tooling:
     runs-on: ubuntu-latest
@@ -37,12 +35,10 @@ jobs:
       - name: conan install (Release)
         timeout-minutes: 2
         run: conan install . -pr:b clang-libcxx -pr:h clang-libcxx -if build --build missing -s build_type=Release
-      - name: build
+      - name: build and test
         run: conan build . -bf build
       - name: clang-tidy (diff)
         run: git diff -U0 --no-color --relative ${{ github.event.pull_request.base.sha }} | python3 /llvm-install/scripts/clang-tidy-diff.py -p1 -path ./build  -clang-tidy-binary /llvm-install/bin/clang-tidy
-      - name: run unit tests
-        run: ./build/tests/unit/luma_av_unit
       - name: apply clang-format (diff)
         run: git diff -U0 --no-color --relative ${{ github.event.pull_request.base.sha }} | python3 /llvm-install/scripts/clang-format-diff.py -v -i -p1 -sort-includes -binary /llvm-install/bin/clang-format
       - name: commit format changes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,9 @@ find_package(ffmpeg REQUIRED)
 
 add_subdirectory(src)
 
-enable_testing()
 find_package(GTest REQUIRED)
-
+enable_testing()
+include(GoogleTest)
 add_subdirectory(tests)
+
 add_subdirectory(examples)

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,6 +35,7 @@ class LumaAvConan(ConanFile):
         cmake.definitions["CMAKE_TOOLCHAIN_FILE"] = "conan_toolchain.cmake"
         cmake.configure()
         cmake.build()
+        cmake.test()
 
     def package(self):
         self.copy("*.hpp", dst="include", src="hello")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,12 +5,16 @@ if(NOT TARGET luma_av::luma_av)
 endif()
 
 add_executable(luma_av_unit 
-               luma_av/frame_tests.cpp
-               luma_av/result_tests.cpp
+               frame_tests.cpp
+               result_tests.cpp
 )
 target_compile_features(luma_av_unit PUBLIC cxx_std_20)
 
 target_link_libraries(luma_av_unit PUBLIC 
    luma_av::luma_av
    GTest::gtest_main
+)
+gtest_discover_tests(luma_av_unit
+                    TEST_SUFFIX .Unit
+                    TEST_LIST UnitTests
 )

--- a/tests/unit/frame_tests.cpp
+++ b/tests/unit/frame_tests.cpp
@@ -10,14 +10,14 @@ using namespace luma_av;
 /**
 memory safe construct and destruct
 */
-TEST(frame_unit, default_ctor) {
+TEST(frame, default_ctor) {
     auto f = Frame::make().value();
 }
 
 /**
 memory safe move construct and destruct
 */
-TEST(frame_unit, default_move) {
+TEST(frame, default_move) {
     auto f = Frame::make().value();
     auto f2 = Frame{std::move(f)};
 }

--- a/tests/unit/frame_tests.cpp
+++ b/tests/unit/frame_tests.cpp
@@ -10,16 +10,14 @@ using namespace luma_av;
 /**
 memory safe construct and destruct
 */
-TEST(frame, default_ctor) {
-    auto f = Frame::make().value();
-}
+TEST(frame, default_ctor) { auto f = Frame::make().value(); }
 
 /**
 memory safe move construct and destruct
 */
 TEST(frame, default_move) {
-    auto f = Frame::make().value();
-    auto f2 = Frame{std::move(f)};
+  auto f = Frame::make().value();
+  auto f2 = Frame{std::move(f)};
 }
 
 // /**

--- a/tests/unit/result_tests.cpp
+++ b/tests/unit/result_tests.cpp
@@ -6,7 +6,7 @@
 
 using namespace luma_av;
 
-TEST(result_unit, outcome_example) {
+TEST(result, outcome_example) {
   std::error_code ec = luma_av::errc::success;
 
   std::cout << "printed by std::error_code as " << ec
@@ -23,19 +23,19 @@ TEST(result_unit, outcome_example) {
   ASSERT_EQ(ec.value(), 0);
 }
 
-TEST(result_unit, success) {
+TEST(result, success) {
   auto r = result<void>{luma_av::outcome::success()};
   ASSERT_TRUE(r);
   r.value();
 }
 
-TEST(result_unit, ffmpeg_code) {
+TEST(result, ffmpeg_code) {
   auto r = result<void>{errc{AVERROR_EOF}};
   ASSERT_FALSE(r);
   ASSERT_DEATH(r.value(), "");
 }
 
-TEST(result_unit, ffmpeg_success) {
+TEST(result, ffmpeg_success) {
   auto r = detail::ffmpeg_code_to_result(0);
   ASSERT_TRUE(r);
   r.value();


### PR DESCRIPTION
cmake files updated to enable test discovery for unit tests with ctest

ctest is now evoked during the conan build method using the approach from here https://docs.conan.io/en/latest/reference/conanfile/methods.html#unit-testing-your-library 

also a few changes to the test project layout/organization which is still a work in progress (: 
